### PR TITLE
Allow higher wagtail versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=2.2, <3.3
-    wagtail>=2.5, <4
+    wagtail>=2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=2.2, <3.3
-    wagtail>=2.5, <3
+    wagtail>=2.5, <4


### PR DESCRIPTION
This PR is realted to the wagtail 3 upgrade on [foundation.mozilla.org](https://github.com/mozilla/foundation.mozilla.org)

PR: https://github.com/mozilla/foundation.mozilla.org/pull/9904/
issue: https://github.com/mozilla/foundation.mozilla.org/issues/9674

I'm not entirely sure _why_ this is limited to wagtail 2, perhaps it was just at the time of forking. [wagtail footnotes](https://github.com/torchbox/wagtail-footnotes) has been updated to support wagtail 3 and 4 - see the commit log [here](https://github.com/torchbox/wagtail-footnotes/commits/main)

It looks like we forked this to support localized footnotes. So we may need to re-fork and reapply our work. Not entirely sure yet.

From testing locally, the footnotes are still working fine

